### PR TITLE
Add EXPOSE to Dockerfile

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,6 +8,7 @@
 # - Server: docker run -p 5201:5201 -it iperf3 -s
 # - Client: docker run -it iperf3 -c 192.168.1.1 (note: since this is a minimal image and does not include DNS, name resolution will not work)
 FROM scratch
+EXPOSE 5201
 COPY src/iperf3 /iperf3
 COPY tmp /tmp
 ENTRYPOINT ["/iperf3"]


### PR DESCRIPTION
You want to ensure it's "documented" that the container wants to open that port.

While it is just "a hint to the next person to maintain the system" so that they know what are the ports should be published when runs the image, it's helpful. EXPOSE doesn't publish it, it just lets docker inspect know the container WANTS to. Helpful for humans, and software which automate containers.

In practicality, when running the image with -P, the exposed ports in dockerfile will be published to avoid a long list of -p for individual ports.

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

